### PR TITLE
Fix vxMinMaxLocNode minCount/maxCount scalar type to VX_TYPE_SIZE (#29)

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -91,17 +91,17 @@ jobs:
             impl_flags: "-DOPENVX_CONFORMANCE_VISION=ON -DOPENVX_USE_ENHANCED_VISION=ON"
             cts_flags: "-DOPENVX_CONFORMANCE_VISION=ON -DOPENVX_USE_ENHANCED_VISION=ON"
             filter: ""
-          # Mode 3 -- Neural Networks (AlexNet needs weights not shipped in
-          # test_data, so it is excluded to avoid a spurious failure).
+          # Mode 3 -- Neural Networks (full suite; AlexNet weights + input
+          # images ship in test_conformance/Networks/Binaries and test_data/images).
           - name: Neural Networks
             impl_flags: "-DOPENVX_CONFORMANCE_NEURAL_NETWORKS=ON"
             cts_flags: "-DOPENVX_CONFORMANCE_NEURAL_NETWORKS=ON"
-            filter: "--filter=-TensorNetworks.AlexNetTestNetwork"
+            filter: ""
           # Mode 5 -- Combined (Vision, Enhanced, NN, NN16, Import/Export, U1)
           - name: Combined
             impl_flags: "-DOPENVX_CONFORMANCE_VISION=ON -DOPENVX_USE_ENHANCED_VISION=ON -DOPENVX_CONFORMANCE_NEURAL_NETWORKS=ON -DOPENVX_USE_NN=ON -DOPENVX_USE_IX=ON -DOPENVX_USE_U1=ON"
             cts_flags: "-DOPENVX_CONFORMANCE_VISION=ON -DOPENVX_USE_ENHANCED_VISION=ON -DOPENVX_CONFORMANCE_NEURAL_NETWORKS=ON -DOPENVX_USE_NN=ON -DOPENVX_USE_IX=ON -DOPENVX_USE_U1=ON"
-            filter: "--filter=-TensorNetworks.AlexNetTestNetwork"
+            filter: ""
           # Mode 6 -- User Data Object
           - name: User Data Object
             impl_flags: "-DOPENVX_USE_USER_DATA_OBJECT=ON"

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -1,0 +1,284 @@
+name: Conformance
+
+# Builds the Khronos OpenVX sample implementation and runs this CTS checkout
+# against it, mirroring the modes from the internal GitLab pipeline
+# (.gitlab-ci.yml) but adapted for GitHub Actions and the public
+# KhronosGroup/OpenVX-sample-impl repository.
+
+on:
+  pull_request:
+  push:
+    branches:
+      - openvx_1.3.2
+  workflow_dispatch:
+
+env:
+  SAMPLE_IMPL_REPO: https://github.com/KhronosGroup/OpenVX-sample-impl.git
+  SAMPLE_IMPL_REF: openvx_1.3.2
+
+jobs:
+  # Stage 1 -- sanity build: confirm this CTS checkout compiles against a
+  # default-feature build of the sample implementation. Gates the test matrix.
+  build:
+    name: Build · CTS + sample impl
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout CTS
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
+            cmake make git python3 gcc g++
+          gcc --version
+
+      - name: Configure paths
+        run: |
+          echo "SAMPLE_IMPL_DIR=$RUNNER_TEMP/sample-impl" >> "$GITHUB_ENV"
+          echo "OPENVX_DIR=$RUNNER_TEMP/sample-impl/install/Linux/x64/Debug" >> "$GITHUB_ENV"
+          echo "VX_TEST_DATA_PATH=$GITHUB_WORKSPACE/test_data/" >> "$GITHUB_ENV"
+
+      - name: Clone sample implementation
+        run: |
+          rm -rf "$SAMPLE_IMPL_DIR"
+          git clone --recursive --branch "$SAMPLE_IMPL_REF" \
+            "$SAMPLE_IMPL_REPO" "$SAMPLE_IMPL_DIR"
+
+      - name: Build sample implementation
+        run: |
+          mkdir -p "$SAMPLE_IMPL_DIR/build/Linux/x64/Debug"
+          cd "$SAMPLE_IMPL_DIR/build/Linux/x64/Debug"
+          cmake "$SAMPLE_IMPL_DIR" \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_INSTALL_PREFIX="$OPENVX_DIR" \
+            -DCMAKE_INSTALL_BINDIR=bin -DCMAKE_INSTALL_LIBDIR=bin \
+            -DBUILD_X64=1
+          make install -j"$(nproc)"
+
+      - name: Build CTS
+        run: |
+          rm -rf "$RUNNER_TEMP/build-cts"
+          mkdir -p "$RUNNER_TEMP/build-cts"
+          cd "$RUNNER_TEMP/build-cts"
+          cmake \
+            -DOPENVX_INCLUDES="$OPENVX_DIR/include" \
+            -DOPENVX_LIBRARIES="$OPENVX_DIR/bin/libopenvx.so;$OPENVX_DIR/bin/libvxu.so;pthread;dl;m;rt" \
+            "$GITHUB_WORKSPACE"
+          cmake --build . -j"$(nproc)"
+
+  # Stage 2 -- conformance test matrix. Each mode rebuilds the sample impl with
+  # its feature flags (features are compiled into libopenvx.so) and runs the
+  # matching slice of the suite, mirroring GitLab modes 1-3, 5-7.
+  conformance:
+    name: Conformance · ${{ matrix.name }}
+    needs: build
+    runs-on: ubuntu-22.04
+    continue-on-error: ${{ matrix.experimental || false }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Mode 1 -- Vision
+          - name: Vision
+            impl_flags: "-DOPENVX_CONFORMANCE_VISION=ON"
+            cts_flags: "-DOPENVX_CONFORMANCE_VISION=ON"
+            filter: ""
+          # Mode 2 -- Vision + Enhanced Vision
+          - name: Vision + Enhanced Vision
+            impl_flags: "-DOPENVX_CONFORMANCE_VISION=ON -DOPENVX_USE_ENHANCED_VISION=ON"
+            cts_flags: "-DOPENVX_CONFORMANCE_VISION=ON -DOPENVX_USE_ENHANCED_VISION=ON"
+            filter: ""
+          # Mode 3 -- Neural Networks (AlexNet needs weights not shipped in
+          # test_data, so it is excluded to avoid a spurious failure).
+          - name: Neural Networks
+            impl_flags: "-DOPENVX_CONFORMANCE_NEURAL_NETWORKS=ON"
+            cts_flags: "-DOPENVX_CONFORMANCE_NEURAL_NETWORKS=ON"
+            filter: "--filter=-TensorNetworks.AlexNetTestNetwork"
+          # Mode 5 -- Combined (Vision, Enhanced, NN, NN16, Import/Export, U1)
+          - name: Combined
+            impl_flags: "-DOPENVX_CONFORMANCE_VISION=ON -DOPENVX_USE_ENHANCED_VISION=ON -DOPENVX_CONFORMANCE_NEURAL_NETWORKS=ON -DOPENVX_USE_NN=ON -DOPENVX_USE_IX=ON -DOPENVX_USE_U1=ON"
+            cts_flags: "-DOPENVX_CONFORMANCE_VISION=ON -DOPENVX_USE_ENHANCED_VISION=ON -DOPENVX_CONFORMANCE_NEURAL_NETWORKS=ON -DOPENVX_USE_NN=ON -DOPENVX_USE_IX=ON -DOPENVX_USE_U1=ON"
+            filter: "--filter=-TensorNetworks.AlexNetTestNetwork"
+          # Mode 6 -- User Data Object
+          - name: User Data Object
+            impl_flags: "-DOPENVX_USE_USER_DATA_OBJECT=ON"
+            cts_flags: "-DOPENVX_USE_USER_DATA_OBJECT=ON"
+            filter: ""
+          # Mode 7 -- Pipelining (run only the pipeline suite)
+          - name: Pipelining
+            impl_flags: "-DOPENVX_CONFORMANCE_VISION=ON -DOPENVX_USE_ENHANCED_VISION=ON -DOPENVX_USE_PIPELINING=ON"
+            cts_flags: "-DOPENVX_CONFORMANCE_VISION=ON -DOPENVX_USE_ENHANCED_VISION=ON -DOPENVX_USE_PIPELINING=ON"
+            filter: "--filter=GraphPipeline.*"
+    steps:
+      - name: Checkout CTS
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
+            cmake make git python3 gcc g++
+
+      - name: Configure paths
+        run: |
+          echo "SAMPLE_IMPL_DIR=$RUNNER_TEMP/sample-impl" >> "$GITHUB_ENV"
+          echo "OPENVX_DIR=$RUNNER_TEMP/sample-impl/install/Linux/x64/Debug" >> "$GITHUB_ENV"
+          echo "VX_TEST_DATA_PATH=$GITHUB_WORKSPACE/test_data/" >> "$GITHUB_ENV"
+
+      - name: Clone sample implementation
+        run: |
+          rm -rf "$SAMPLE_IMPL_DIR"
+          git clone --recursive --branch "$SAMPLE_IMPL_REF" \
+            "$SAMPLE_IMPL_REPO" "$SAMPLE_IMPL_DIR"
+
+      - name: Build sample implementation
+        run: |
+          mkdir -p "$SAMPLE_IMPL_DIR/build/Linux/x64/Debug"
+          cd "$SAMPLE_IMPL_DIR/build/Linux/x64/Debug"
+          cmake "$SAMPLE_IMPL_DIR" \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_INSTALL_PREFIX="$OPENVX_DIR" \
+            -DCMAKE_INSTALL_BINDIR=bin -DCMAKE_INSTALL_LIBDIR=bin \
+            -DBUILD_X64=1 ${{ matrix.impl_flags }}
+          make install -j"$(nproc)"
+
+      - name: Build CTS
+        run: |
+          rm -rf "$RUNNER_TEMP/build-cts"
+          mkdir -p "$RUNNER_TEMP/build-cts"
+          cd "$RUNNER_TEMP/build-cts"
+          cmake \
+            -DOPENVX_INCLUDES="$OPENVX_DIR/include" \
+            -DOPENVX_LIBRARIES="$OPENVX_DIR/bin/libopenvx.so;$OPENVX_DIR/bin/libvxu.so;pthread;dl;m;rt" \
+            ${{ matrix.cts_flags }} "$GITHUB_WORKSPACE"
+          cmake --build . -j"$(nproc)"
+
+      - name: Run conformance
+        run: |
+          cd "$RUNNER_TEMP/build-cts"
+          LD_LIBRARY_PATH="$OPENVX_DIR/bin:./lib" \
+            ./bin/vx_test_conformance ${{ matrix.filter }}
+
+  # Mode 4 -- NNEF Import. Needs extra include path + links libnnef-lib.a and
+  # stdc++. The sample impl's NNEF submodule uses std::numeric_limits without
+  # including <limits>, so force-include it on the impl build.
+  nnef-import:
+    name: Conformance · NNEF Import
+    needs: build
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout CTS
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
+            cmake make git python3 gcc g++
+
+      - name: Configure paths
+        run: |
+          echo "SAMPLE_IMPL_DIR=$RUNNER_TEMP/sample-impl" >> "$GITHUB_ENV"
+          echo "OPENVX_DIR=$RUNNER_TEMP/sample-impl/install/Linux/x64/Debug" >> "$GITHUB_ENV"
+          echo "VX_TEST_DATA_PATH=$GITHUB_WORKSPACE/test_data/" >> "$GITHUB_ENV"
+
+      - name: Clone sample implementation
+        run: |
+          rm -rf "$SAMPLE_IMPL_DIR"
+          git clone --recursive --branch "$SAMPLE_IMPL_REF" \
+            "$SAMPLE_IMPL_REPO" "$SAMPLE_IMPL_DIR"
+
+      - name: Build sample implementation (NNEF)
+        run: |
+          mkdir -p "$SAMPLE_IMPL_DIR/build/Linux/x64/Debug"
+          cd "$SAMPLE_IMPL_DIR/build/Linux/x64/Debug"
+          cmake "$SAMPLE_IMPL_DIR" \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_INSTALL_PREFIX="$OPENVX_DIR" \
+            -DCMAKE_INSTALL_BINDIR=bin -DCMAKE_INSTALL_LIBDIR=bin \
+            -DBUILD_X64=1 \
+            -DOPENVX_CONFORMANCE_NNEF_IMPORT=ON \
+            -DCMAKE_CXX_FLAGS="-include limits"
+          make install -j"$(nproc)"
+
+      - name: Build and run CTS (NNEF)
+        run: |
+          rm -rf "$RUNNER_TEMP/build-cts"
+          mkdir -p "$RUNNER_TEMP/build-cts"
+          cd "$RUNNER_TEMP/build-cts"
+          cmake \
+            -DOPENVX_INCLUDES="$OPENVX_DIR/include" \
+            -DOPENVX_LIBRARIES="$OPENVX_DIR/bin/libopenvx.so;$OPENVX_DIR/bin/libvxu.so;$OPENVX_DIR/bin/libnnef-lib.a;pthread;dl;m;rt;stdc++" \
+            -DOPENVX_CONFORMANCE_NNEF_IMPORT=ON \
+            -DCMAKE_C_FLAGS="-I$SAMPLE_IMPL_DIR/kernels/NNEF-Tools/parser/cpp/include" \
+            "$GITHUB_WORKSPACE"
+          cmake --build . -j"$(nproc)"
+          LD_LIBRARY_PATH="$OPENVX_DIR/bin:./lib" ./bin/vx_test_conformance
+
+  # Mode 8 -- Streaming. The streaming + event-queue APIs are stubs in the
+  # sample implementation, so this job is allowed to fail and surfaces only as
+  # a warning (mirrors GitLab `allow_failure: true`).
+  streaming:
+    name: Conformance · Streaming (warn-only)
+    needs: build
+    runs-on: ubuntu-22.04
+    continue-on-error: true
+    steps:
+      - name: Checkout CTS
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
+            cmake make git python3 gcc g++
+
+      - name: Configure paths
+        run: |
+          echo "SAMPLE_IMPL_DIR=$RUNNER_TEMP/sample-impl" >> "$GITHUB_ENV"
+          echo "OPENVX_DIR=$RUNNER_TEMP/sample-impl/install/Linux/x64/Debug" >> "$GITHUB_ENV"
+          echo "VX_TEST_DATA_PATH=$GITHUB_WORKSPACE/test_data/" >> "$GITHUB_ENV"
+
+      - name: Clone sample implementation
+        run: |
+          rm -rf "$SAMPLE_IMPL_DIR"
+          git clone --recursive --branch "$SAMPLE_IMPL_REF" \
+            "$SAMPLE_IMPL_REPO" "$SAMPLE_IMPL_DIR"
+
+      - name: Build sample implementation (Streaming)
+        run: |
+          mkdir -p "$SAMPLE_IMPL_DIR/build/Linux/x64/Debug"
+          cd "$SAMPLE_IMPL_DIR/build/Linux/x64/Debug"
+          cmake "$SAMPLE_IMPL_DIR" \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_INSTALL_PREFIX="$OPENVX_DIR" \
+            -DCMAKE_INSTALL_BINDIR=bin -DCMAKE_INSTALL_LIBDIR=bin \
+            -DBUILD_X64=1 \
+            -DOPENVX_CONFORMANCE_VISION=ON -DOPENVX_USE_ENHANCED_VISION=ON \
+            -DOPENVX_USE_PIPELINING=ON -DOPENVX_USE_STREAMING=ON
+          make install -j"$(nproc)"
+
+      - name: Build and run CTS (Streaming)
+        run: |
+          rm -rf "$RUNNER_TEMP/build-cts"
+          mkdir -p "$RUNNER_TEMP/build-cts"
+          cd "$RUNNER_TEMP/build-cts"
+          cmake \
+            -DOPENVX_INCLUDES="$OPENVX_DIR/include" \
+            -DOPENVX_LIBRARIES="$OPENVX_DIR/bin/libopenvx.so;$OPENVX_DIR/bin/libvxu.so;pthread;dl;m;rt" \
+            -DOPENVX_CONFORMANCE_VISION=ON -DOPENVX_USE_ENHANCED_VISION=ON \
+            -DOPENVX_USE_PIPELINING=ON -DOPENVX_USE_STREAMING=ON \
+            "$GITHUB_WORKSPACE"
+          cmake --build . -j"$(nproc)"
+          if ! LD_LIBRARY_PATH="$OPENVX_DIR/bin:./lib" ./bin/vx_test_conformance '--filter=GraphStreaming.*'; then
+            echo "::warning title=Streaming conformance::Streaming/event-queue APIs are stubbed in the sample implementation; failures are expected."
+          fi

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -27,6 +27,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+          lfs: true
 
       - name: Install build dependencies
         run: |
@@ -117,6 +118,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+          lfs: true
 
       - name: Install build dependencies
         run: |
@@ -176,6 +178,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+          lfs: true
 
       - name: Install build dependencies
         run: |
@@ -235,6 +238,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+          lfs: true
 
       - name: Install build dependencies
         run: |

--- a/README.md
+++ b/README.md
@@ -6,7 +6,36 @@ The OpenVX Conformance Test Suite (CTS) verifies that an OpenVX implementation c
 
 - **CMake** 3.10 or later
 - **C99-compatible compiler** (GCC, Clang, or MSVC)
+- **Git LFS** — required to fetch the binary test images in `test_data/` (see [Cloning](#cloning) below)
 - An OpenVX implementation — either a pre-built library or the Khronos sample implementation
+
+## Cloning
+
+Since the `openvx_1.3.2` branch, the binary test images in `test_data/` (e.g. `lena.bmp`) are stored using [Git LFS](https://git-lfs.com/). **Install Git LFS before cloning**, otherwise `test_data/` will contain small text pointer files instead of the actual images.
+
+```bash
+# Install Git LFS (once per machine), then enable it for your user
+git lfs install
+
+# Clone as usual — LFS objects are fetched automatically
+git clone <repository-url>
+```
+
+If you already cloned without Git LFS, install it and then pull the real files:
+
+```bash
+git lfs install
+git lfs pull
+```
+
+Without Git LFS the files appear present on disk, but the CTS fails at runtime with errors such as:
+
+```
+FAILED at test_engine/test_image.c:387
+    Can't open image file: lena.bmp
+```
+
+> **Note:** This applies to `openvx_1.3.2` and later. The `openvx_1.3` branch stored test images as regular git blobs and did not require Git LFS.
 
 ## Building
 

--- a/test_conformance/test_matchtemplate.c
+++ b/test_conformance/test_matchtemplate.c
@@ -92,14 +92,14 @@ TEST_WITH_ARG(MatchTemplate, testGraphProcessing, method_type_arg,
     VX_CALL(vxVerifyGraph(graph));
     VX_CALL(vxProcessGraph(graph));
 
-    uint32_t mincount = 0, maxcount = 0;
+    vx_size mincount = 0, maxcount = 0;
     vx_scalar minval_, maxval_, mincount_, maxcount_;
     vx_array minloc_ = 0, maxloc_ = 0;
     vx_enum sctype = VX_TYPE_INT16;
     minval_ = ct_scalar_from_int(context, sctype, 0);
     maxval_ = ct_scalar_from_int(context, sctype, 0);
-    mincount_ = ct_scalar_from_int(context, VX_TYPE_UINT32, 0);
-    maxcount_ = ct_scalar_from_int(context, VX_TYPE_UINT32, 0);
+    mincount_ = ct_scalar_from_int(context, VX_TYPE_SIZE, 0);
+    maxcount_ = ct_scalar_from_int(context, VX_TYPE_SIZE, 0);
     minloc_ = vxCreateArray(context, VX_TYPE_COORDINATES2D, 300);
     maxloc_ = vxCreateArray(context, VX_TYPE_COORDINATES2D, 300);
     node = vxMinMaxLocNode(graph, vx_result_image, minval_, maxval_,
@@ -172,14 +172,14 @@ TEST_WITH_ARG(MatchTemplate,  testImmediateProcessing, method_type_arg,
 
     VX_CALL(vxuMatchTemplate(context, vx_source_image, vx_template_image, arg_->type, vx_result_image));
 
-    uint32_t mincount = 0, maxcount = 0;
+    vx_size mincount = 0, maxcount = 0;
     vx_scalar minval_, maxval_, mincount_, maxcount_;
     vx_array minloc_ = 0, maxloc_ = 0;
     vx_enum sctype = VX_TYPE_INT16;
     minval_ = ct_scalar_from_int(context, sctype, 0);
     maxval_ = ct_scalar_from_int(context, sctype, 0);
-    mincount_ = ct_scalar_from_int(context, VX_TYPE_UINT32, 0);
-    maxcount_ = ct_scalar_from_int(context, VX_TYPE_UINT32, 0);
+    mincount_ = ct_scalar_from_int(context, VX_TYPE_SIZE, 0);
+    maxcount_ = ct_scalar_from_int(context, VX_TYPE_SIZE, 0);
     minloc_ = vxCreateArray(context, VX_TYPE_COORDINATES2D, 300);
     maxloc_ = vxCreateArray(context, VX_TYPE_COORDINATES2D, 300);
     VX_CALL(vxuMinMaxLoc(context, vx_result_image, minval_, maxval_,

--- a/test_conformance/test_minmaxloc.c
+++ b/test_conformance/test_minmaxloc.c
@@ -28,12 +28,13 @@
 typedef vx_coordinates2d_t Point;
 
 static void reference_minmaxloc(CT_Image src, int* _minval, int* _maxval,
-                                uint32_t* _mincount, uint32_t* _maxcount)
+                                vx_size* _mincount, vx_size* _maxcount)
 {
     Point pt={0, 0};
     int minval = INT_MAX, maxval = INT_MIN;
     int format = src ? src->format : VX_DF_IMAGE_U8;
-    uint32_t mincount = 0, maxcount = 0, stride;
+    vx_size mincount = 0, maxcount = 0;
+    uint32_t stride;
 
     ASSERT(src);
     ASSERT(src->width > 0 && src->height > 0);
@@ -162,7 +163,8 @@ TEST_WITH_ARG(MinMaxLoc, testOnRandom, format_arg,
     uint64_t rng;
     int a, b;
     int minval0 = 0, maxval0 = 0, minval = 0, maxval = 0;
-    uint32_t mincount0 = 0, maxcount0 = 0, mincount = 0, maxcount = 0;
+    vx_size mincount0 = 0, maxcount0 = 0;
+    vx_size mincount = 0, maxcount = 0;
     vx_scalar minval_, maxval_, mincount_, maxcount_;
     vx_array minloc_ = 0, maxloc_ = 0;
     vx_enum sctype = format == VX_DF_IMAGE_U8 ? VX_TYPE_UINT8 :
@@ -181,8 +183,8 @@ TEST_WITH_ARG(MinMaxLoc, testOnRandom, format_arg,
 
     minval_ = ct_scalar_from_int(context, sctype, 0);
     maxval_ = ct_scalar_from_int(context, sctype, 0);
-    mincount_ = ct_scalar_from_int(context, VX_TYPE_UINT32, 0);
-    maxcount_ = ct_scalar_from_int(context, VX_TYPE_UINT32, 0);
+    mincount_ = ct_scalar_from_int(context, VX_TYPE_SIZE, 0);
+    maxcount_ = ct_scalar_from_int(context, VX_TYPE_SIZE, 0);
     minloc_ = vxCreateArray(context, VX_TYPE_COORDINATES2D, MAX_CAP);
     maxloc_ = vxCreateArray(context, VX_TYPE_COORDINATES2D, MAX_CAP);
     ASSERT(vxGetStatus((vx_reference)minloc_) == VX_SUCCESS && vxGetStatus((vx_reference)maxloc_) == VX_SUCCESS);
@@ -267,8 +269,8 @@ TEST_WITH_ARG(MinMaxLoc, testOnRandom, format_arg,
                                      "\tActual:   minval=%d, maxval=%d, mincount=%d, maxcount=%d\n",
                                      __FUNCTION__, __FILE__, __LINE__,
                                      iter, width, height,
-                                     minval0, maxval0, mincount0, maxcount0,
-                                     minval, maxval, mincount, maxcount);
+                                     minval0, maxval0, (int)mincount0, (int)maxcount0,
+                                     minval, maxval, (int)mincount, (int)maxcount);
             break;
         }
 

--- a/test_conformance/test_minmaxloc.c
+++ b/test_conformance/test_minmaxloc.c
@@ -265,12 +265,12 @@ TEST_WITH_ARG(MinMaxLoc, testOnRandom, format_arg,
         if( minval != minval0 || maxval != maxval0 || mincount != mincount0 || maxcount != maxcount0 )
         {
             CT_RecordFailureAtFormat("Test case %d. width=%d, height=%d,\n"
-                                     "\tExpected: minval=%d, maxval=%d, mincount=%d, maxcount=%d\n"
-                                     "\tActual:   minval=%d, maxval=%d, mincount=%d, maxcount=%d\n",
+                                     "\tExpected: minval=%d, maxval=%d, mincount=%zu, maxcount=%zu\n"
+                                     "\tActual:   minval=%d, maxval=%d, mincount=%zu, maxcount=%zu\n",
                                      __FUNCTION__, __FILE__, __LINE__,
                                      iter, width, height,
-                                     minval0, maxval0, (int)mincount0, (int)maxcount0,
-                                     minval, maxval, (int)mincount, (int)maxcount);
+                                     minval0, maxval0, (size_t)mincount0, (size_t)maxcount0,
+                                     minval, maxval, (size_t)mincount, (size_t)maxcount);
             break;
         }
 


### PR DESCRIPTION
## Summary

The OpenVX 1.3 specification requires the minCount and maxCount parameters of xMinMaxLocNode to be `VX_TYPE_SIZE` scalars:

> minCount / maxCount: [optional] The total number of detected minimums/maximums in image. **Use a VX_TYPE_SIZE scalar.**

The conformance test in `test_conformance/test_minmaxloc.c` was instead creating these scalars as `VX_TYPE_UINT32`. This does not match the specified API contract and can:

- cause false failures against spec-correct implementations that validate the scalar type as `VX_TYPE_SIZE` at graph verification, and
- mask non-conformant implementations that only accept `VX_TYPE_UINT32`.

This matters in practice on LP64 platforms (Linux/macOS/ARM64) where `vx_size` is 8 bytes vs 4 for `uint32_t`.

## Changes

- `reference_minmaxloc()` count parameters: `uint32_t*` -> `vx_size*`
- Local count variables in the reference helper and in `testOnRandom`: `uint32_t` -> `vx_size`
- Count scalars created with `VX_TYPE_SIZE` instead of `VX_TYPE_UINT32`
- Diagnostic `printf` count values cast to `int` to avoid `-Wformat` warnings on 64-bit builds

This is the `#29` fix originally proposed in #36, applied in isolation.

## Test plan

- [ ] Build the CTS
- [ ] Run `*MinMaxLoc*` conformance tests against a 1.3.2 implementation on x86_64 and ARM64

Made with [Cursor](https://cursor.com)